### PR TITLE
Clear uploaded files on validation error

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -9,9 +9,14 @@ if (! function_exists('oldFile')) {
     function oldFile($key = null, $default = null) {
         /** @var Illuminate\Session\Store $session */
         $session = app('session');
+
+        /** @var \Illuminate\Support\ViewErrorBag $errors */
+        $errors = $session->get('errors', new \Illuminate\Support\MessageBag());
+
         $fileBag = new Symfony\Component\HttpFoundation\FileBag();
         if ($files = $session->get('_remembered_files', null)) {
             foreach($files as $k => $f) {
+                if ($errors->has($k)) { continue; }
                 $fileBag->set(
                     $k,
                     new Illuminate\Http\UploadedFile(

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,7 +4,7 @@ if (! function_exists('oldFile')) {
     /**
      * @param null|string $key
      * @param null|mixed $default
-     * @return mixed|\Symfony\Component\HttpFoundation\FileBag|Symfony\Component\HttpFoundation\File\UploadedFile
+     * @return mixed|\Symfony\Component\HttpFoundation\FileBag|Illuminate\Http\UploadedFile
      */
     function oldFile($key = null, $default = null) {
         /** @var Illuminate\Session\Store $session */
@@ -14,7 +14,7 @@ if (! function_exists('oldFile')) {
             foreach($files as $k => $f) {
                 $fileBag->set(
                     $k,
-                    new Symfony\Component\HttpFoundation\File\UploadedFile(
+                    new Illuminate\Http\UploadedFile(
                         $f['tmpPathName'],
                         $f['originalName'],
                         $f['mimeType'],

--- a/tests/UploadTest.php
+++ b/tests/UploadTest.php
@@ -61,13 +61,7 @@ class UploadTest extends TestCase
         $remembered = $session->get('_remembered_files', []);
         $this->assertEquals([], $remembered);
 
-        $stub = __DIR__.DIRECTORY_SEPARATOR.'stubs'.DIRECTORY_SEPARATOR.'test.jpg';
-        $name = str_random(8).'.jpg';
-        $path = sys_get_temp_dir().DIRECTORY_SEPARATOR.$name;
-
-        copy($stub, $path);
-
-        $file = new UploadedFile($path, $name, filesize($path), 'image/jpeg', null, true);
+        $file = $this->mockUploadedFile(__DIR__.DIRECTORY_SEPARATOR.'stubs'.DIRECTORY_SEPARATOR.'test.jpg');
 
         $response = $this->call('POST', 'test', [], [], ['img' => $file], ['Accept' => 'application/json']);
         $this->assertTrue($response->isOk());
@@ -77,7 +71,7 @@ class UploadTest extends TestCase
 
         $remembered = $session->get('_remembered_files');
         $this->assertArrayHasKey('img', $remembered);
-        $this->assertEquals($name, $remembered['img']['originalName']);
+        $this->assertEquals($file->getClientOriginalName(), $remembered['img']['originalName']);
 
         //
         // Test that the view composer sets the right properties
@@ -126,16 +120,9 @@ class UploadTest extends TestCase
         /** @var Store $session */
         $session = $this->app->make(Store::class);
 
-
-        // Copy Stub File
-        $stub = __DIR__.DIRECTORY_SEPARATOR.'stubs'.DIRECTORY_SEPARATOR.'test.jpg';
-        $name = str_random(8).'.jpg';
-        $path = sys_get_temp_dir().DIRECTORY_SEPARATOR.$name;
-
-        copy($stub, $path);
-
         // Post the File the first time
-        $file = new UploadedFile($path, $name, filesize($path), 'image/jpeg', null, true);
+        $file = $this->mockUploadedFile(__DIR__.DIRECTORY_SEPARATOR.'stubs'.DIRECTORY_SEPARATOR.'test.jpg');
+
         $this->call('POST', 'test-request', [], [], ['img' => $file], ['Accept' => 'application/json']);
         $session->ageFlashData();
 
@@ -163,13 +150,7 @@ class UploadTest extends TestCase
         $remembered = $session->get('_remembered_files', []);
         $this->assertEquals([], $remembered);
 
-        $stub = __DIR__.DIRECTORY_SEPARATOR.'stubs'.DIRECTORY_SEPARATOR.'test.jpg';
-        $name = str_random(8).'.jpg';
-        $path = sys_get_temp_dir().DIRECTORY_SEPARATOR.$name;
-
-        copy($stub, $path);
-
-        $file = new UploadedFile($path, $name, filesize($path), 'image/jpeg', null, true);
+        $file = $this->mockUploadedFile(__DIR__.DIRECTORY_SEPARATOR.'stubs'.DIRECTORY_SEPARATOR.'test.jpg');
 
         $response = $this->call('POST', 'test', [], [], ['img' => $file], ['Accept' => 'application/json']);
         $this->assertTrue($response->isOk());
@@ -177,7 +158,7 @@ class UploadTest extends TestCase
 
         // "Refresh"...
 
-        $response = $this->call('POST', 'test', ['_rememberedFiles' => ['img' => $name]], [], [], ['Accept' => 'application/json']);
+        $response = $this->call('POST', 'test', ['_rememberedFiles' => ['img' => $file->getClientOriginalName()]], [], [], ['Accept' => 'application/json']);
         $this->assertTrue($response->isOk());
         $session->ageFlashData();
 
@@ -206,13 +187,7 @@ class UploadTest extends TestCase
         $remembered = $session->get('_remembered_files', []);
         $this->assertEquals([], $remembered);
 
-        $stub = __DIR__.DIRECTORY_SEPARATOR.'stubs'.DIRECTORY_SEPARATOR.'test.jpg';
-        $name = str_random(8).'.jpg';
-        $path = sys_get_temp_dir().DIRECTORY_SEPARATOR.$name;
-
-        copy($stub, $path);
-
-        $file = new UploadedFile($path, $name, filesize($path), 'image/jpeg', null, true);
+        $file = $this->mockUploadedFile(__DIR__.DIRECTORY_SEPARATOR.'stubs'.DIRECTORY_SEPARATOR.'test.jpg');
 
         $response = $this->call('POST', 'test', [], [], ['img' => $file], ['Accept' => 'application/json']);
         $this->assertTrue($response->isOk());
@@ -229,6 +204,46 @@ class UploadTest extends TestCase
         $this->assertTrue(oldFile('test', true));
         $this->assertFalse(oldFile('test', false));
 
+    }
+
+    /**
+     * Test written for issue #2
+     * @see https://github.com/photogabble/laravel-remember-uploads/issues/2
+     */
+    public function testValidationPasses()
+    {
+        /**
+         * @var \Illuminate\Routing\Router $router
+         */
+        $router = $this->app->make('router');
+        $router->post(
+            'test-validation',
+            [
+                'middleware' => ['remember.files'],
+                'uses' => '\Photogabble\LaravelRememberUploads\Tests\Stubs\ValidationTestController@fileUpload'
+            ]
+        );
+
+        /** @var Store $session */
+        $session = $this->app->make(Store::class);
+
+        $response = $this->call('POST', 'test-validation', [], [], [], ['Accept' => 'application/json']);
+        $this->assertFalse($response->isOk());
+
+        $file = $this->mockUploadedFile(__DIR__.DIRECTORY_SEPARATOR.'stubs'.DIRECTORY_SEPARATOR.'test.jpg');
+
+        $response = $this->call('POST', 'test-validation', [], [], ['img' => $file], ['Accept' => 'application/json']);
+        $this->assertTrue($response->isOk());
+
+        $session->ageFlashData();
+    }
+
+    private function mockUploadedFile($stub) {
+        $name = str_random(8).'.jpg';
+        $path = sys_get_temp_dir().DIRECTORY_SEPARATOR.$name;
+
+        copy($stub, $path);
+        return new UploadedFile($path, $name, filesize($path), 'image/jpeg', null, true);
     }
 
     private function mockView()

--- a/tests/stubs/ValidationTestController.php
+++ b/tests/stubs/ValidationTestController.php
@@ -8,15 +8,25 @@ use Illuminate\Routing\Controller;
 
 class ValidationTestController extends Controller
 {
-
     use ValidatesRequests;
 
     public function fileUpload(Request $request)
     {
         $this->validate($request, [
-            'img' => 'required_without:_rememberedFiles[img]|mimes:jpeg'
+            'img' => 'required_without:_rememberedFiles.img|mimes:jpeg'
         ]);
 
-        $n =1;
+        $file = oldFile('img', $request->file('img'));
+
+        return json_encode([
+            'name' => $file->getFilename()
+        ]);
+    }
+
+    public function failedFileUpload(Request $request)
+    {
+        $this->validate($request, [
+            'img' => 'required_without:_rememberedFiles.img|mimes:png'
+        ]);
     }
 }

--- a/tests/stubs/ValidationTestController.php
+++ b/tests/stubs/ValidationTestController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Photogabble\LaravelRememberUploads\Tests\Stubs;
+
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class ValidationTestController extends Controller
+{
+
+    use ValidatesRequests;
+
+    public function fileUpload(Request $request)
+    {
+        $this->validate($request, [
+            'img' => 'required_without:_rememberedFiles[img]|mimes:jpeg'
+        ]);
+
+        $n =1;
+    }
+}


### PR DESCRIPTION
The only way I could hook this behavior in, is via the `oldFile` method. 